### PR TITLE
In order to recognize tags with parameter like [color=#ff00ff][/color]

### DIFF
--- a/BBCodeParser/BBCodeParser.m
+++ b/BBCodeParser/BBCodeParser.m
@@ -122,9 +122,9 @@ static NSString *__closingTag = @"/";
         NSString *validBegining1 = [NSString stringWithFormat:@"%@%@%@", __startTag, tag, __endTag]; // "[bold]"
         NSString *validBegining2 = [NSString stringWithFormat:@"%@%@%@%@", __startTag, __closingTag, tag, __endTag]; // "[/bold]"
         NSString *validBegining3 = [NSString stringWithFormat:@"%@%@ ", __startTag, tag]; // "[bold "
-        NSString *validBegining3 = [NSString stringWithFormat:@"%@%@=", __startTag, tag]; // "[color="
+        NSString *validBegining4 = [NSString stringWithFormat:@"%@%@=", __startTag, tag]; // "[bold="
         
-        if ([text hasPrefix:validBegining1] || [text hasPrefix:validBegining2] || [text hasPrefix:validBegining3])
+        if ([text hasPrefix:validBegining1] || [text hasPrefix:validBegining2] || [text hasPrefix:validBegining3] || [text hasPrefix:validBegining4])
             return YES;
     }
     


### PR DESCRIPTION
I really recommend supporting tags with parameters:

I would like to either have a tag or an attribute as element.

The control flow of the application needs to distinct between tags or attributes anyway.
I could either have a single tag element with attributes or an attribute element with further attributes. 

This change is just a hot fix for recognizing such tags as well and let the client application handle that case which works fine for the moment but should be replaced by a clean structure.
